### PR TITLE
Rename files on download if passed an array of names

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -40,15 +40,20 @@ function sameDomain(url) {
 	return location.hostname === a.hostname && location.protocol === a.protocol;
 }
 
-function download(url) {
+function download(url,fileName) {
 	var a = document.createElement('a');
-	a.download = '';
+	if(fileName){
+		a.download = fileName;
+	}else{
+		a.download = '';
+	}
+
 	a.href = url;
 	// firefox doesn't support `a.click()`...
 	a.dispatchEvent(new MouseEvent('click'));
 }
 
-module.exports = function (urls) {
+module.exports = function (urls,fileNames) {
 	if (!urls) {
 		throw new Error('`urls` required');
 	}
@@ -58,14 +63,19 @@ module.exports = function (urls) {
 	}
 
 	var delay = 0;
-
+	var i = 0;
 	urls.forEach(function (url) {
 		// the download init has to be sequential for firefox if the urls are not on the same domain
 		if (isFirefox() && !sameDomain(url)) {
 			return setTimeout(download.bind(null, url), 100 * ++delay);
 		}
 
-		download(url);
+		if(fileNames[i]){
+			download(url,fileNames[i]);
+			++i;	
+		}else{
+			download(url);
+		}		
 	});
 }
 


### PR DESCRIPTION
Implementation of https://github.com/sindresorhus/multi-download/issues/4

If an array of file names is passed like this:
```
var names = ['1.zip','2.zip','3.zip'];
document.querySelector('#download-btn').addEventListener('click', function (e) {
				var files = e.target.dataset.files.split(' ');
				multiDownload(files,names);
			});
```

the files will be renamed accordingly. It is not required to specify all the names. If  the array of names is shorter, other files will get their original names.

Since this attribute is [honored for resources with same origin] (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download), the *fileNames* parameter is not passed for the case 
```
isFirefox() && !sameDomain(url)
```