### PR TITLE
Fix #4 - add possibility to pass function to rename files

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -41,17 +41,20 @@ function sameDomain(url) {
 	return location.hostname === a.hostname && location.protocol === a.protocol;
 }
 
-function download(url) {
+function download(url, name) {
 	var a = document.createElement('a');
-	a.download = '';
+	a.download = name || '';
 	a.href = url;
 	// firefox doesn't support `a.click()`...
 	a.dispatchEvent(new MouseEvent('click'));
 }
 
-module.exports = function (urls) {
+module.exports = function (urls, renameFn) {
 	if (!urls) {
 		throw new Error('`urls` required');
+	}
+	if (!renameFn) {
+		renameFn = function () { return ''; };
 	}
 
 	if (typeof document.createElement('a').download === 'undefined') {
@@ -60,15 +63,20 @@ module.exports = function (urls) {
 
 	var delay = 0;
 
-	urls.forEach(function (url) {
+	urls.map(function (url, index, urls) {
+		return {
+			url: url,
+			name: renameFn(url, index, urls)
+		};
+	}).forEach(function (obj) {
 		// the download init has to be sequential for firefox if the urls are not on the same domain
-		if (isFirefox() && !sameDomain(url)) {
-			return setTimeout(download.bind(null, url), 100 * ++delay);
+		if (isFirefox() && !sameDomain(obj.url)) {
+			return setTimeout(download.bind(null, obj.url, obj.name), 100 * ++delay);
 		}
 
-		download(url);
+		download(obj.url, obj.name);
 	});
-}
+};
 
 },{}]},{},[1])(1)
 });

--- a/index.html
+++ b/index.html
@@ -7,24 +7,37 @@
 		<title>multi-download</title>
 		<link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
 		<style>
-			#download-btn {
-				width: 300px;
+			#download-btn, #download-rename-btn {
 				height: 50px;
 				position: absolute;
 				left: 50%;
-				top: 50%;
-				margin: -25px 0 0 -150px;
+				transform: translate(-50%, -50%);
 				outline: none;
+			}
+			#download-btn {
+				top: calc(50% - 30px);
+			}
+			#download-rename-btn {
+				top: calc(50% + 30px);
 			}
 		</style>
 	</head>
 	<body >
 		<button id="download-btn" class="btn btn-primary btn-lg" data-files="fixture/unicorn.jpg.zip fixture/rainbow.jpg.zip fixture/unicorn2.jpg.zip">Download multiple files</button>
+		<button id="download-rename-btn" class="btn btn-primary btn-lg" data-files="fixture/unicorn.jpg.zip fixture/rainbow.jpg.zip fixture/unicorn2.jpg.zip">Download multiple files and rename them</button>
 		<script src="browser.js"></script>
 		<script>
 			document.querySelector('#download-btn').addEventListener('click', function (e) {
 				var files = e.target.dataset.files.split(' ');
 				multiDownload(files);
+			});
+
+			document.querySelector('#download-rename-btn').addEventListener('click', function (e) {
+				var files = e.target.dataset.files.split(' ');
+				multiDownload(files, function (url, index, urls) {
+					var extension = url.substring(url.lastIndexOf('.') + 1);
+					return 'file' + index + '.' + extension;
+				});
 			});
 		</script>
 	</body>

--- a/index.js
+++ b/index.js
@@ -40,17 +40,20 @@ function sameDomain(url) {
 	return location.hostname === a.hostname && location.protocol === a.protocol;
 }
 
-function download(url) {
+function download(url, name) {
 	var a = document.createElement('a');
-	a.download = '';
+	a.download = name || '';
 	a.href = url;
 	// firefox doesn't support `a.click()`...
 	a.dispatchEvent(new MouseEvent('click'));
 }
 
-module.exports = function (urls) {
+module.exports = function (urls, renameFn) {
 	if (!urls) {
 		throw new Error('`urls` required');
+	}
+	if (!renameFn) {
+		renameFn = function () { return ''; };
 	}
 
 	if (typeof document.createElement('a').download === 'undefined') {
@@ -59,12 +62,17 @@ module.exports = function (urls) {
 
 	var delay = 0;
 
-	urls.forEach(function (url) {
+	urls.map(function (url, index, urls) {
+		return {
+			url: url,
+			name: renameFn(url, index, urls)
+		};
+	}).forEach(function (obj) {
 		// the download init has to be sequential for firefox if the urls are not on the same domain
-		if (isFirefox() && !sameDomain(url)) {
-			return setTimeout(download.bind(null, url), 100 * ++delay);
+		if (isFirefox() && !sameDomain(obj.url)) {
+			return setTimeout(download.bind(null, obj.url, obj.name), 100 * ++delay);
 		}
 
-		download(url);
+		download(obj.url, obj.name);
 	});
-}
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-download",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Download multiple files at once",
   "license": "MIT",
   "repository": "sindresorhus/multi-download",


### PR DESCRIPTION
Add second argument to `multiDownload`. It's a function which takes 3 arguments: `url, index, urls`. It's expected to return new filename (string) for each url.
Fixes #4 and #9.