### PR TITLE
Use the fallback for Chrome 65 due to a bug in the browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -34,6 +34,11 @@ function isFirefox() {
 	return /Firefox\//i.test(navigator.userAgent);
 }
 
+function isChrome65() {
+    // sadder panda :(
+    return /Chrome\/65/i.test(navigator.userAgent);
+}
+
 function sameDomain(url) {
 	var a = document.createElement('a');
 	a.href = url;
@@ -54,7 +59,7 @@ module.exports = function (urls) {
 		throw new Error('`urls` required');
 	}
 
-	if (typeof document.createElement('a').download === 'undefined') {
+	if (typeof document.createElement('a').download === 'undefined' || isChrome65()) {
 		return fallback(urls);
 	}
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,11 @@ function isFirefox() {
 	return /Firefox\//i.test(navigator.userAgent);
 }
 
+function isChrome65() {
+    // sadder panda :(
+    return /Chrome\/65/i.test(navigator.userAgent);
+}
+
 function sameDomain(url) {
 	var a = document.createElement('a');
 	a.href = url;
@@ -53,7 +58,7 @@ module.exports = function (urls) {
 		throw new Error('`urls` required');
 	}
 
-	if (typeof document.createElement('a').download === 'undefined') {
+	if (typeof document.createElement('a').download === 'undefined' || isChrome65()) {
 		return fallback(urls);
 	}
 


### PR DESCRIPTION
Chrome 66 works fine so there is no need to use the fallback mechanism for it.

Fixes https://github.com/sindresorhus/multi-download/issues/19.